### PR TITLE
Fixed docker-compose description

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ services:
 ```
 
 Run `docker-compose up -d db`, wait a minute for MySQL to be initialized (or tail logs with `docker-compose logs -f`) 
-then run `docker-compose up flyway`.
+then run `docker-compose up --no-recreate flyway`.


### PR DESCRIPTION
The docker-compose description states that flyway should be run using
"docker-compose up flyway". However this causes docker-compose to
restart the database container and the flyway command to fail.

Added --no-recreate to command to avoid restart of db container.