### PR TITLE
Update alpine base image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk11:alpine-jre
 
 RUN apk --no-cache add --update bash openssl
 


### PR DESCRIPTION
- Update jdk
- Update alpine 3.7 to 3.9
  - Fixes CVE-2019-5747