### PR TITLE
Bumping alpine image to Flyway 6.1.0

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /flyway
 # Change to the flyway user
 USER flyway
 
-ENV FLYWAY_VERSION 6.0.8
+ENV FLYWAY_VERSION 6.1.0
 
 RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
   && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz \


### PR DESCRIPTION
I tried to use https://github.com/flyway/flyway/issues/2254 in `flyway/flyway:6.1.0-alpine` and was taking this error
```
ERROR: Invalid argument: -json
```

Found that Flyway was never bumped in the alpine image
```
docker pull flyway/flyway:6.1.0-alpine
6.1.0-alpine: Pulling from flyway/flyway
Digest: sha256:d73e9d8d2a8eb9a1ff7967afcdaa491ee1853930ea93befa18a2d8e991d509d1
Status: Image is up to date for flyway/flyway:6.1.0-alpine
docker.io/flyway/flyway:6.1.0-alpine

docker run -it --rm flyway/flyway:6.1.0-alpine -v
Flyway Community Edition 6.0.8 by Redgate
```

Thus, bumping.