### PR TITLE
Create the flyway group in the alpine image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,7 +3,8 @@ FROM openjdk:8-jre-alpine
 RUN apk --no-cache add --update bash openssl
 
 # Add the flyway user and step in the directory
-RUN adduser -S -h /flyway -D flyway
+RUN addgroup flyway \
+    && adduser -S -h /flyway -D -G flyway flyway
 WORKDIR /flyway
 
 # Change to the flyway user


### PR DESCRIPTION
Currently, the alpine image is missing the flyway group, since the alpine specific user creation command doesn't have the ability to automatically create the group. This can cause confusion with docker image commands like `COPY --chown=flyway:flyway ./src/main/sql/ /flyway/sql`. This pull request adds a group creation command to the alpine Dockerfile.