### PR TITLE
Pin versions (recommended by hadolint)

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk --no-cache add --update bash openssl
+RUN apk --no-cache add --update bash=4.4.19-r1 openssl=1.1.1g-r0
 
 # Add the flyway user and step in the directory
 RUN addgroup flyway \


### PR DESCRIPTION
Hadolint recommends we pin the versions of bash and openssl that we pull in rather than defaulting to latest. This means we have a little more safety from pulling in unexpected changes.