### PR TITLE
Use JDK 11 for regular docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:12-jre-hotspot
+FROM adoptopenjdk:11-jre-hotspot
 
 # Add the flyway user and step in the directory
 RUN adduser --system --home /flyway --disabled-password --group flyway


### PR DESCRIPTION
JDK 11 is the current LTS JDK, so it makes sense to stick with this until we make use of features in newer JDKs

Note that there isn't an alpine image for JDK 11, so our alpine image remains as it is (JDK 12)