### PR TITLE
Docker fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PERL = docker run --rm -w /app -v "$(realpath .):/app" perl:5-slim perl
 BASH = docker run --rm bash:5 bash
 
 release: update_version wait_for_artifacts test
-	git commit -a -m 'Update to $(VERSION)'
+	git commit --allow-empty -a -m 'Update to $(VERSION)'
 	git tag v$(VERSION)
 	git push origin --atomic $(shell git rev-parse --abbrev-ref HEAD) v$(VERSION)
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:16-alpine
 
-RUN apk --no-cache add --update bash=4.4.19-r1 openssl=1.1.1g-r0
+RUN apk --no-cache add --update bash openssl
 
 # Add the flyway user and step in the directory
 RUN addgroup flyway \


### PR DESCRIPTION
(i) `--allow-empty` means that we can re-run a release for a given version if something fails (otherwise git throws an error over the empty commit resulting from updating the version number)

(ii) removing the pinned versions is required as the older ones are no longer appropriate - they were (I think) a fix to make openjdk-12 work. 