### PR TITLE
use adoptopenjdk/openjdk11:alpine-jre in Flyway Alpine image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-alpine
+FROM adoptopenjdk/openjdk11:alpine-jre
 
 RUN apk --no-cache add --update bash openssl
 


### PR DESCRIPTION
As described in https://github.com/flyway/flyway-docker/issues/45, the Flyway Alpine image uses a JDK instead of a JRE.

This pull request changes the Flyway Alpine base image to [`adoptopenjdk/openjdk11:alpine-jre`](https://github.com/AdoptOpenJDK/openjdk-docker/blob/master/11/jre/alpine/Dockerfile.hotspot.releases.full). 

This pull request reduces the Flyway Alpine image size from about 380 MB to about 210 MB.