### PR TITLE
Use Adopt OpenJDK 11 JRE as alpine base image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-alpine
+FROM adoptopenjdk/openjdk11:alpine-jre
 
 RUN apk --no-cache add --update bash openssl
 


### PR DESCRIPTION
We currently use OpenJDK16 which comes with a JDK, and makes the alpine image large. This changes the base image to use version 11 with just a JRE (I chose 11 as it is the LTS version)