### PR TITLE
Migrate AdoptOpenJDK 11-jre-alpine to eclipse-temurin 11-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 # Add the flyway user and step in the directory
 RUN adduser --system --home /flyway --disabled-password --group flyway

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:11-alpine
 
 RUN apk --no-cache add --update bash openssl
 


### PR DESCRIPTION
AdoptOpenJDK 11-jre-alpine has been deprecated and replaced with eclipse-temurin images. We now have a alpine version to work with.

> [This image is officially deprecated in favor of the eclipse-temurin image, and will receive no further updates after 2021-08-01 (Aug 01, 2021). Please adjust your usage accordingly.](https://hub.docker.com/_/adoptopenjdk)

https://github.com/flyway/flyway-docker/issues/56