### PR TITLE
Add arm64/v8 support to Alpine Dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
-FROM eclipse-temurin:11-alpine
+FROM alpine:3.15.0
 
-RUN apk --no-cache add --update bash openssl
+RUN apk --no-cache add --update bash openssl openjdk8-jre
 
 # Add the flyway user and step in the directory
 RUN addgroup flyway \


### PR DESCRIPTION
Hi there, thanks for supporting these images for us.

As the lucky owner of a new M1 Macbook I have a vested interest in getting an official flyway image working that has support for the `arm64/v8` architecture that the M1 uses.

The current `eclipse-temurin:11-alpine` base image for the alpine dockerfile supports `arm64` but not `arm64/v8`. If I swap out this base image to the latest plain alpine image, and install the same JDK that `eclipse-temurin:11-alpine` uses (`openjdk8-jre`) it seems to work great.

Would this be a reasonable change for you to accept into the core repo?