### PR TITLE
Fix Issue #31: Add checksum and PGP key validation before installing flyway-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre
 
 RUN adduser --system --home /flyway --disabled-password --group flyway
 WORKDIR /flyway

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,39 @@
-FROM eclipse-temurin:11-jre
+FROM docker.io/library/eclipse-temurin:11-jre
 
 RUN adduser --system --home /flyway --disabled-password --group flyway
 WORKDIR /flyway
+
+# This is a requirement to securely manage software installation; it will be cleaned up before the OCI container image build completes.
+RUN apt-get update && apt-get install --no-install-recommends --yes gnupg2
 
 USER flyway
 
 ENV FLYWAY_VERSION 8.5.4
 
-RUN curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz -o flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+# Fetch and import public key into GPG keyring
+# https://www.spinics.net/lists/trinity-devel/msg01400.html
+RUN gpg --keyserver hkp://pgp.mit.edu:11371 \ 
+--recv-keys F79157DB93697AA32CD4C46CC485C5A843FADB15
+
+RUN curl -SLO https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+  # Download the GPG detached signature for the tarball.
+  && curl -SLO https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz.asc \
+  # Download the checksum for the tarball.
+  && curl -SLO https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz.sha1 \
+  # Use GPG to verify that the tarball was signed by the owner of the key obtained.
+  && gpg --verify flyway-commandline-${FLYWAY_VERSION}.tar.gz.asc flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+  #	Test that the stated checksum matches the tarball checksum by using the sha1sum tool.
+  && echo "$(cat flyway-commandline-${FLYWAY_VERSION}.tar.gz.sha1)  flyway-commandline-${FLYWAY_VERSION}.tar.gz"  | sha1sum -c - \
+  # If software package verification succeeds, install flyway-commandline
   && gzip -d flyway-commandline-${FLYWAY_VERSION}.tar.gz \
   && tar -xf flyway-commandline-${FLYWAY_VERSION}.tar --strip-components=1 \
   && rm flyway-commandline-${FLYWAY_VERSION}.tar
+
+USER root  
+# Remove virtual package
+RUN apt-get remove --yes gnupg2
+
+USER flyway
 
 ENV PATH="/flyway:${PATH}"
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:11-jre-alpine
 
 RUN apk --no-cache add --update bash openssl
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,18 +1,42 @@
-FROM eclipse-temurin:11-jre-alpine
+FROM docker.io/library/eclipse-temurin:11-jre-alpine
 
 RUN apk --no-cache add --update bash openssl
 
 RUN addgroup flyway && adduser -S -h /flyway -D -G flyway flyway
 WORKDIR /flyway
 
+# This is a requirement to securely manage software installation; it will be cleaned up before the OCI container image build completes.
+RUN apk add --no-cache --virtual .build-deps \
+    gnupg
+
 USER flyway
 
 ENV FLYWAY_VERSION 8.5.4
 
+# Fetch and import public key into GPG keyring
+# https://www.spinics.net/lists/trinity-devel/msg01400.html
+RUN gpg --keyserver hkp://pgp.mit.edu:11371 \ 
+--recv-keys F79157DB93697AA32CD4C46CC485C5A843FADB15
+
 RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+  # Download the GPG detached signature for the tarball.
+  && wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz.asc \
+  # Download the checksum for the tarball.
+  && wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz.sha1 \
+  # Use GPG to verify that the tarball was signed by the owner of the key obtained.
+  && gpg --verify flyway-commandline-${FLYWAY_VERSION}.tar.gz.asc flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+  #	Test that the stated checksum matches the tarball checksum by using the sha1sum tool.
+  && echo "$(cat flyway-commandline-${FLYWAY_VERSION}.tar.gz.sha1)  flyway-commandline-${FLYWAY_VERSION}.tar.gz"  | sha1sum -c - \
+  # If software package verification succeeds, install flyway-commandline
   && gzip -d flyway-commandline-${FLYWAY_VERSION}.tar.gz \
   && tar -xf flyway-commandline-${FLYWAY_VERSION}.tar --strip-components=1 \
   && rm flyway-commandline-${FLYWAY_VERSION}.tar
+
+USER root
+# Remove virtual package
+RUN apk del .build-deps
+
+USER flyway
 
 ENV PATH="/flyway:${PATH}"
 

--- a/flyway-azure/alpine/Dockerfile
+++ b/flyway-azure/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM docker.io/library/node:10-alpine
 
 # This file builds images which are suitable for use in Azure Pipeline agent jobs; these require more elements
 # to be present than the minimal Flyway commandline container.
@@ -40,7 +40,25 @@ RUN set -x \
 
 WORKDIR /flyway
 
-RUN curl -L https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz -o flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+# This is a requirement to securely manage software installation; it will be cleaned up before the OCI container image build completes.
+RUN apk add --no-cache --virtual .build-deps \
+    gnupg
+
+# Fetch and import public key into GPG keyring
+# https://www.spinics.net/lists/trinity-devel/msg01400.html
+RUN gpg --keyserver hkp://pgp.mit.edu:11371 \ 
+--recv-keys F79157DB93697AA32CD4C46CC485C5A843FADB15
+
+RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+  # Download the GPG detached signature for the tarball.
+  && wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz.asc \
+  # Download the checksum for the tarball.
+  && wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz.sha1 \
+  # Use GPG to verify that the tarball was signed by the owner of the key obtained.
+  && gpg --verify flyway-commandline-${FLYWAY_VERSION}.tar.gz.asc flyway-commandline-${FLYWAY_VERSION}.tar.gz \
+  #	Test that the stated checksum matches the tarball checksum by using the sha1sum tool.
+  && echo "$(cat flyway-commandline-${FLYWAY_VERSION}.tar.gz.sha1)  flyway-commandline-${FLYWAY_VERSION}.tar.gz"  | sha1sum -c - \
+  # If software package verification succeeds, install flyway-commandline
   && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz --strip-components=1 \
   && rm flyway-commandline-${FLYWAY_VERSION}.tar.gz \
   && chmod +x /flyway/flyway \

--- a/flyway-azure/alpine/Dockerfile
+++ b/flyway-azure/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:10-alpine
+FROM node:10-alpine
 
 # This file builds images which are suitable for use in Azure Pipeline agent jobs; these require more elements
 # to be present than the minimal Flyway commandline container.


### PR DESCRIPTION
This PR fixes Issue #31 and provides an additional security enhancement of verifying the PGP key used to create the detached signature file.

In each Dockerfile the following flyway-cli installation workflow occurs:

1. Get the PGP public key used to sign the GPG detached signature file, `flyway-commandline-${FLYWAY_VERSION}.tar.gz.asc` . 
2. Download the flyway-cli tarball. 
3. Download the GPG detached signature file for the tarball.
4. Download the checksum for the tarball. 
6. Use GPG to verify that the tarball was signed by the owner of the key obtained.
7. Test that the stated checksum matches the tarball checksum by using the sha1sum tool.
8. If software package verification succeeds, install flyway-cli.

I also cleaned up the extra packages required.

 
