### PR TITLE
Pull newest base image if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,17 @@ wait_for_artifacts:
 build:
 	-docker buildx rm multi_arch_builder
 	docker buildx create --name multi_arch_builder --driver-opt network=bridge --use
-	docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --build-arg FLYWAY_VERSION=$(VERSION) \
+	docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --pull --build-arg FLYWAY_VERSION=$(VERSION) \
 	-t flyway/flyway:latest \
 	-t flyway/flyway:$(VERSION) \
 	-t flyway/flyway:$(subst $S,.,$(wordlist 1,2,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION))) \
 	-t flyway/flyway:$(subst $S,.,$(wordlist 1,1,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION))) .
-	docker build --build-arg FLYWAY_VERSION=$(VERSION) \
+	docker build --pull --build-arg FLYWAY_VERSION=$(VERSION) \
 	-t flyway/flyway:latest-alpine \
 	-t flyway/flyway:$(VERSION)-alpine \
 	-t flyway/flyway:$(subst $S,.,$(wordlist 1,2,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION)))-alpine \
 	-t flyway/flyway:$(subst $S,.,$(wordlist 1,1,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION)))-alpine ./alpine
-	docker build --build-arg FLYWAY_VERSION=$(VERSION) \
+	docker build --pull --build-arg FLYWAY_VERSION=$(VERSION) \
 	-t flyway/flyway-azure:latest-alpine \
 	-t flyway/flyway-azure:$(VERSION)-alpine \
 	-t flyway/flyway-azure:$(subst $S,.,$(wordlist 1,2,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION)))-alpine \

--- a/enterprise/Makefile
+++ b/enterprise/Makefile
@@ -16,17 +16,17 @@ wait_for_artifacts:
 	$(BASH) -c 'until wget -q --spider --user-agent="Mozilla" $(URL) &> /dev/null; do sleep 2; done'
 
 build:
-	docker build --build-arg FLYWAY_VERSION=$(VERSION) \
+	docker build --pull --build-arg FLYWAY_VERSION=$(VERSION) \
 	-t redgate/flyway:latest \
 	-t redgate/flyway:$(VERSION) \
 	-t redgate/flyway:$(subst $S,.,$(wordlist 1,2,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION))) \
 	-t redgate/flyway:$(subst $S,.,$(wordlist 1,1,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION))) .
-	docker build --build-arg FLYWAY_VERSION=$(VERSION) \
+	docker build --pull --build-arg FLYWAY_VERSION=$(VERSION) \
 	-t redgate/flyway:latest-alpine \
 	-t redgate/flyway:$(VERSION)-alpine \
 	-t redgate/flyway:$(subst $S,.,$(wordlist 1,2,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION)))-alpine \
 	-t redgate/flyway:$(subst $S,.,$(wordlist 1,1,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION)))-alpine ./alpine
-	docker build --build-arg FLYWAY_VERSION=$(VERSION) \
+	docker build --pull --build-arg FLYWAY_VERSION=$(VERSION) \
 	-t redgate/flyway:latest-azure \
 	-t redgate/flyway:$(VERSION)-azure \
 	-t redgate/flyway:$(subst $S,.,$(wordlist 1,2,$(subst .,$S,$(subst -,$S,$(VERSION)))))$(wordlist 2,2,$(subst -,$S-,$(VERSION)))-azure \


### PR DESCRIPTION
When building docker images for Flyway, check if there is a newer version of the base image available and pull if present. 

Makes sure image gets any vulnerability fixes when base image is changed. 