### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre-focal as flyway
 
 RUN apt-get update \
-    && apt-get install -y python3-pip \
+    && apt-get install -y python3-pip=20.0.* \ 
     && pip3 install sqlfluff==1.2.1
 
 WORKDIR /flyway
@@ -27,6 +27,6 @@ RUN curl -L https://packages.microsoft.com/config/ubuntu/21.04/packages-microsof
   && dpkg -i packages-microsoft-prod.deb \
   && rm packages-microsoft-prod.deb
 RUN apt-get update \
-    && apt-get install -y apt-transport-https \
+    && apt-get install -y apt-transport-https=2.0.* \ 
     && apt-get update \
     && apt-get install -y dotnet-runtime-6.0


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved from the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance