### PR TITLE
Add version label to Dockefiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends python3-pip \
     && apt-get install -y --no-install-recommends libc6 libgcc1 libgcc-s1 libgssapi-krb5-2 libicu70 liblttng-ust1 libssl3 libstdc++6 libunwind8 zlib1g \
     && pip3 install sqlfluff==1.2.1
-    
+
+LABEL org.opencontainers.image.version ${FLYWAY_VERSION}

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -24,3 +24,5 @@ FROM flyway as redgate
 RUN apk add --no-cache icu-libs krb5-libs libgcc libintl libssl3 libstdc++ zlib \
     && apk --no-cache add --update python3 py3-pip \
     && pip3 install sqlfluff==1.2.1
+
+LABEL org.opencontainers.image.version ${FLYWAY_VERSION}

--- a/azure/Dockerfile
+++ b/azure/Dockerfile
@@ -40,3 +40,5 @@ FROM flyway as redgate
 RUN apk add --no-cache icu-libs krb5-libs libgcc libintl libssl3 libstdc++ zlib icu \
   && apk --no-cache add --update g++ python3 python3-dev py3-pip \
   && pip3 install sqlfluff==1.2.1
+
+LABEL org.opencontainers.image.version ${FLYWAY_VERSION}


### PR DESCRIPTION
Having version label in Dockefiles would help to properly identify running flyway containers.